### PR TITLE
Fix: changed @particle-network/chains version to ^1.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@particle-network/auth": "latest",
     "@particle-network/auth-core": "1.3.6",
     "@particle-network/auth-core-modal": "latest",
-    "@particle-network/chains": "^latest",
+    "@particle-network/chains": "^1.4.9",
     "@particle-network/provider": "^1.3.2",
     "@particle-network/thresh-sig": "^0.7.8",
     "@particle-network/wallet": "^1.3.4",


### PR DESCRIPTION
This pull request fixes an issue with the dependency version of `@particle-network/chains`. The version was previously set to `^latest`, which caused issues with dependency resolution. It has now been updated to `^1.4.9` to ensure compatibility and stability.